### PR TITLE
Move reset cache argument

### DIFF
--- a/src/cli/getAssets.js
+++ b/src/cli/getAssets.js
@@ -9,11 +9,14 @@ async function getAssets(options) {
     dev: false,
     minify: false,
     platform: 'ios',
-    resetCache: options.resetCache,
   };
 
   const config = await loadConfig(
-    { cwd: process.cwd(), config: options.config },
+    {
+      cwd: process.cwd(),
+      config: options.config,
+      resetCache: options.resetCache,
+    },
     {
       resolver: {
         resolverMainFields: ['react-native', 'browser', 'main'],


### PR DESCRIPTION
Seems like the `--reset-cache` argument does not have any effect when its passed as `config`. Moved it to the base options and now it works.

First try is without the change and second try is with this change.

<img width="389" alt="Screenshot 2021-11-02 at 09 41 20" src="https://user-images.githubusercontent.com/1987198/139813792-e12e1e19-7f71-4435-ac0f-135feb3541af.png">


