### PR TITLE
Replace current color references with static values

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ yarn react-native-vector-image generate
 | `--no-ios-output`     | Disable iOS output.                             | `false`                       |
 | `--android-output`    | Path to an Android `res` folder.                | `android/app/src/main/res`    |
 | `--no-android-output` | Disable Android output.                         | `false`                       |
+| `--current-color`       | Replace any `current` color references in SVGs. | `#000000`                       |
+| `--current-color-dark`       | Replace any `current` color references in `.dark.svg` SVGs. | `#ffffff`                       |
 
 ### Step 3: recompile
 

--- a/src/cli/fixtures/current-color.svg
+++ b/src/cli/fixtures/current-color.svg
@@ -1,0 +1,1 @@
+<svg height="50" viewBox="0 0 50 50" width="50" xmlns="http://www.w3.org/2000/svg"><path d="m.5.5h49v49h-49z" fill="current" fill-rule="evenodd" stroke="current"/></svg>

--- a/src/cli/generateAssets.js
+++ b/src/cli/generateAssets.js
@@ -5,6 +5,7 @@ const generateAndroidAsset = require('./generateAndroidAsset');
 const getAssets = require('./getAssets');
 const getResourceName = require('../getResourceName');
 const resolveAssetSources = require('./resolveAssetSources');
+const readSvgAsset = require('./readSvgAsset');
 const { InputError, TransformationError } = require('./errors');
 
 async function removeGeneratedAssets(directory) {
@@ -28,6 +29,8 @@ async function generateAssets({
   config,
   entryFile,
   resetCache,
+  currentColor,
+  currentColorDark,
 }) {
   const assets = await getAssets({ config, entryFile, resetCache });
 
@@ -54,8 +57,8 @@ async function generateAssets({
 
           const resourceName = getResourceName(asset);
           const source = {
-            light: fs.readFileSync(light).toString(),
-            dark: dark && fs.readFileSync(dark).toString(),
+            light: readSvgAsset(light, currentColor),
+            dark: dark && readSvgAsset(dark, currentColorDark),
             width: asset.width,
             height: asset.height,
           };

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -44,6 +44,16 @@ function main(argv) {
           description: 'Path to an Android `res` folder',
           default: 'android/app/src/main/res',
         },
+        'current-color': {
+          description: 'Replace any `current` color references in SVGs.',
+          default: '#000000',
+          type: 'string',
+        },
+        'current-color-dark': {
+          description: 'Replace any `current` color references in `.dark.svg` SVGs.',
+          default: '#ffffff',
+          type: 'string',
+        },
       },
       async (options) => {
         try {

--- a/src/cli/readSvgAsset.js
+++ b/src/cli/readSvgAsset.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+
+const readSvgAsset = (path, currentColor) =>
+  fs
+    .readFileSync(path)
+    .toString()
+    .replace(
+      /\s(fill|stroke|stop-color|flood-color|lighting-color)=["']current["']/g,
+      (_, attribute) => ` ${attribute}="${currentColor}"`
+    );
+
+module.exports = readSvgAsset;

--- a/src/cli/readSvgAsset.spec.js
+++ b/src/cli/readSvgAsset.spec.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const readSvgAsset = require('./readSvgAsset');
+
+describe('readSvgAsset', () => {
+  it('replaces fill="current" with supplied currentColor', () => {
+    const svg = readSvgAsset(
+      path.join(__dirname, 'fixtures', 'current-color.svg'),
+      'red'
+    );
+    expect(svg).toContain('fill="red"');
+  });
+});


### PR DESCRIPTION
As the title states, this PR looks for `current` color references in the SVGs and replaces them with a specific static color as this currently breaks on Android. 

This approach is a bit naive, and doesn't support use cases where SVGs would supply this themselves, but that would require XML parsing and much more complicated logic. If anyone has that use case, I'm happy to accept PRs doing that. 