### PR TITLE
Fix xcode archive failure when build path contains spaces

### DIFF
--- a/strip_svgs.sh
+++ b/strip_svgs.sh
@@ -6,5 +6,5 @@
 RN_ASSETS_PATH="$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/assets"
 
 if [ -d "$RN_ASSETS_PATH" ]; then
-  find $RN_ASSETS_PATH -type f -name "*.svg" -delete 
+  find "$RN_ASSETS_PATH" -type f -name "*.svg" -delete 
 fi


### PR DESCRIPTION
Found out when changed configuration name