### PR TITLE
add support for RN 73 with backwards compatibility

### DIFF
--- a/src/cli/getAssets.js
+++ b/src/cli/getAssets.js
@@ -7,7 +7,7 @@ const getBabelTransformerPath = () => {
     // for RN 73+
     return require.resolve('@react-native/metro-babel-transformer');
   } catch (e) {
-    // to unsure backwards compatibility with old RN versions (RN < 73)
+    // to ensure backwards compatibility with old RN versions (RN < 73)
     return require.resolve('metro-react-native-babel-transformer');
   }
 }

--- a/src/cli/getAssets.js
+++ b/src/cli/getAssets.js
@@ -2,6 +2,16 @@ const Server = require('metro/src/Server');
 const { loadConfig } = require('metro-config');
 const output = require('metro/src/shared/output/bundle');
 
+const getBabelTransformerPath = () => {
+  try {
+    // for RN 73+
+    return require.resolve('@react-native/metro-babel-transformer');
+  } catch (e) {
+    // to unsure backwards compatibility with old RN versions (RN < 73)
+    return require.resolve('metro-react-native-babel-transformer');
+  }
+}
+
 async function getAssets(options) {
   const args = {
     entryFile: options.entryFile,
@@ -22,9 +32,7 @@ async function getAssets(options) {
       },
       transformer: {
         allowOptionalDependencies: true,
-        babelTransformerPath: require.resolve(
-          'metro-react-native-babel-transformer'
-        ),
+        babelTransformerPath: getBabelTransformerPath(),
         assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
       },
     }


### PR DESCRIPTION
With RN 73 the `metro-react-native-babel-transformer` was moved to `@react-native/metro-babel-transformer`.
This adds support for RN 73 with backwards compatibility