### PR TITLE
fix: clear Metro cache after generating native assets

### DIFF
--- a/src/cli/generateAssets.js
+++ b/src/cli/generateAssets.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
 const generateIosAsset = require('./generateIosAsset');
 const generateAndroidAsset = require('./generateAndroidAsset');
@@ -83,6 +84,14 @@ async function generateAssets({
         }
       })
   );
+
+  // Clear Metro's cache after generating native assets so the dev server
+  // recomputes asset hashes to match the regenerated native resources.
+  // Without this, a stale Metro cache can serve an old content hash after
+  // SVG files change (e.g. after a rebase), causing "Could not find image"
+  // warnings at runtime.
+  const metroCacheDir = path.join(os.tmpdir(), 'metro-cache');
+  await fs.remove(metroCacheDir);
 }
 
 module.exports = generateAssets;


### PR DESCRIPTION
## Problem

When SVG file content changes (e.g. after a `git rebase`), running `expo prebuild` generates native assets with new content hashes (e.g. `icon_svg_220cf9`). However, the Metro dev server maintains its own persistent cache from before the change, so at runtime it resolves the old hash (e.g. `icon_svg_884cf1`). This causes warnings like:

```
WARN  Could not find image file:///...Neko.app/askneko_svg_884cf1.png
```

The root cause is that `generateAssets` spins up its own Metro instance via `createMetroServerAndBundleRequestAsync` to discover assets, but the dev server's `$TMPDIR/metro-cache` is a separate persistent cache that doesn't get invalidated.

## Fix

Clear `$TMPDIR/metro-cache` at the end of `generateAssets()`, after native assets have been written. This forces the next `expo start` to recompute all asset hashes from scratch, ensuring they match the freshly generated native resources.

The trade-off is a slightly slower first Metro startup after prebuild (cold cache), but it eliminates the hash mismatch class of bugs entirely.

## Test plan

- Confirmed in a production Expo app where a given SVG had hash `884cf1` before rebase and `220cf9` after
- After applying this patch, `expo prebuild` clears the Metro cache and subsequent `expo start` resolves the correct hash